### PR TITLE
Fix memory leak from NewStringUTF strings

### DIFF
--- a/lujavrite.c
+++ b/lujavrite.c
@@ -164,6 +164,12 @@ call(lua_State *L)
 
   LL = NULL;
 
+  for (int i = 0; i < n; i++) {
+    if (args[i].l != NULL) {
+      (*J)->DeleteLocalRef(J, args[i].l);
+    }
+  }
+
   if ((*J)->ExceptionCheck(J)) {
     (*J)->ExceptionDescribe(J);
     exit(66);


### PR DESCRIPTION
Each call to NewStringUTF creates a local JNI reference, which must be explicitly released with DeleteLocalRef to avoid exhausting the local reference table. This patch ensures that all created Java strings are properly freed after use.

Not releasing local references can lead to memory leaks in the Java heap as well, especially when JNI code repeatedly allocates references without cleaning them up.