### PR TITLE
Use _GNU_SOURCE instead of __USE_GNU for portability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,9 @@ project(lujavrite C)
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 
+add_compile_definitions(
+    _GNU_SOURCE
+)
 add_compile_options(-Wall -Wextra)
 
 find_package(Lua REQUIRED)

--- a/lujavrite.c
+++ b/lujavrite.c
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 #include <assert.h>
-#define __USE_GNU 1
 #include <dlfcn.h>
 
 #include <jni.h>


### PR DESCRIPTION
Switching to _GNU_SOURCE ensures proper feature enabling and better compatibility with glibc standards.  Avoids directly defining internal macros like __USE_GNU.